### PR TITLE
Add OpenAI fixture agent with DataAccessor-backed commands

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 4.3.6
+- Added the OpenAI AI assistant fixture agent that executes JSON commands through `DataAccessor` with the caller's permissions.
+- Seeded an `openai` administrator account, granted AI assistant tokens to default groups, and documented the workflow.
+
 ## 4.3.5
 - Anchored the AI assistant panel as a fixed overlay that shifts the entire layout width instead of living inside the content container.
 - Persisted the chat open state and selected model across Inertia navigations via a shared viewport manager and updated documentation.

--- a/docs/AiAssistant.md
+++ b/docs/AiAssistant.md
@@ -23,6 +23,25 @@ The default configuration registers the in-memory `dummy` model that always repl
 The fixture configuration enables the assistant with this dummy model so the chat can be exercised locally without any external
 dependencies.
 
+## Fixture OpenAI Agent
+
+The fixture now also registers an `openai` model that executes structured commands against the database. The agent expects JSON instructions and uses `DataAccessor` under the hood, so every operation is filtered by the requesting user's permissions.
+
+Example payload for creating a record:
+
+```json
+{
+  "action": "create",
+  "entity": "Example",
+  "data": {
+    "title": "Hello from the assistant",
+    "description": "Generated through the OpenAI agent"
+  }
+}
+```
+
+If the user lacks the required access token (for example, `create-example-model`), the agent responds with an authorization error instead of touching the database. The `openai` fixture user (`login: openai`, `password: openai`) belongs to the administrators group, granting full access for experimentation. Regular users can be granted permissions by assigning the `ai-assistant-openai` token to their groups.
+
 ## Backend Overview
 
 * `AiAssistantHandler` keeps registered model services and in-memory conversation history per user and model.

--- a/fixture/adminizerConfig.ts
+++ b/fixture/adminizerConfig.ts
@@ -437,8 +437,8 @@ const config: AdminpanelConfig = {
     },
     aiAssistant: {
         enabled: true,
-        defaultModel: 'dummy',
-        models: ['dummy'],
+        defaultModel: 'openai',
+        models: ['openai', 'dummy'],
     },
     routePrefix: routePrefix,
     // routePrefix: "/admin",

--- a/fixture/helpers/seedDatabase.ts
+++ b/fixture/helpers/seedDatabase.ts
@@ -27,21 +27,26 @@ export async function seedDatabase(
 
   // ------------------ Groups ------------------ //
   const groupNames = [
-    { name: 'Admins', description: 'System administrators' },
-    { name: 'Users', description: 'Registered users', tokens: 
+    { name: 'Admins', description: 'System administrators', tokens: [
+      'ai-assistant-dummy',
+      'ai-assistant-openai',
+    ] },
+    { name: 'Users', description: 'Registered users', tokens:
       [
         "create-test-model",
         "read-test-model",
         "update-test-model",
         "delete-test-model",
 
-         "create-example-model",
-         "read-example-model",
-         "update-example-model",
-        
-         "read-jsonschema-model",
-        ] 
-      },
+        "create-example-model",
+        "read-example-model",
+        "update-example-model",
+
+        "read-jsonschema-model",
+        "ai-assistant-dummy",
+        "ai-assistant-openai",
+      ]
+    },
     { name: 'Guests', description: 'Guest access' },
   ];
 
@@ -67,6 +72,7 @@ export async function seedDatabase(
     { login: 'admin', password: 'admin', fullName: 'Admin User', isAdministrator: true },
     { login: 'user2', password: 'user2', fullName: 'User Two' },
     { login: 'user3', password: 'user3', fullName: 'User Three', isConfirmed: true },
+    { login: 'openai', password: 'openai', fullName: 'OpenAI Agent', isAdministrator: true, isConfirmed: true },
   ];
 
   for (const u of users) {

--- a/src/lib/ai-assistant/OpenAiModelService.ts
+++ b/src/lib/ai-assistant/OpenAiModelService.ts
@@ -1,0 +1,229 @@
+import {AbstractAiModelService} from './AbstractAiModelService';
+import {AiAssistantMessage} from '../../interfaces/types';
+import {UserAP} from '../../models/UserAP';
+import {Adminizer} from '../Adminizer';
+import {ActionType, ModelConfig} from '../../interfaces/adminpanelConfig';
+import {Entity} from '../../interfaces/types';
+import {DataAccessor} from '../DataAccessor';
+
+type AgentAction = 'create' | 'list' | 'update' | 'delete';
+
+interface AgentInstruction {
+    action: AgentAction;
+    entity: string;
+    payload?: Record<string, unknown>;
+    criteria?: Record<string, unknown>;
+}
+
+type DataAccessorFactory = (entity: Entity, user: UserAP, action: ActionType) => DataAccessor;
+
+const ACTION_TOKENS: Record<ActionType, 'create' | 'read' | 'update' | 'delete'> = {
+    add: 'create',
+    edit: 'update',
+    list: 'read',
+    view: 'read',
+    remove: 'delete',
+};
+
+export class OpenAiModelService extends AbstractAiModelService {
+    private readonly createAccessor: DataAccessorFactory;
+
+    public constructor(adminizer: Adminizer, accessorFactory?: DataAccessorFactory) {
+        super(adminizer, {
+            id: 'openai',
+            name: 'OpenAI fixture agent',
+            description: 'Executes structured commands with DataAccessor using the current user permissions.',
+        });
+        this.createAccessor = accessorFactory ?? ((entity, user, action) => new DataAccessor(adminizer, user, entity, action));
+    }
+
+    public async generateReply(prompt: string, _history: AiAssistantMessage[], user: UserAP): Promise<string> {
+        const instruction = this.parseInstruction(prompt);
+
+        if (!instruction) {
+            return this.usageMessage();
+        }
+
+        switch (instruction.action) {
+            case 'create':
+                return this.handleCreate(instruction, user);
+            default:
+                return `Unsupported action "${instruction.action}". The OpenAI agent currently supports only the "create" action.`;
+        }
+    }
+
+    private async handleCreate(instruction: AgentInstruction, user: UserAP): Promise<string> {
+        const entity = this.resolveEntity(instruction.entity);
+        if (!entity || !entity.model) {
+            return `Model "${instruction.entity}" is not available in this project.`;
+        }
+
+        if (!this.userHasPermission(entity, user, 'add')) {
+            return `User "${user.login}" does not have permission to create ${entity.name} records.`;
+        }
+
+        if (!instruction.payload || typeof instruction.payload !== 'object') {
+            return 'The "create" action requires a "data" object with field values.';
+        }
+
+        try {
+            const accessor = this.createAccessor(entity, user, 'add');
+            const created = await entity.model.create(instruction.payload as any, accessor);
+            const preview = JSON.stringify(created, null, 2);
+            const recordId = this.extractPrimaryKey(created, entity);
+            const idMessage = recordId !== undefined ? ` (id: ${recordId})` : '';
+            return `Record created in ${entity.name}${idMessage}:\n${preview}`;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            Adminizer.log.error('OpenAI agent failed to create record', error);
+            return `Failed to create ${entity.name} record: ${message}`;
+        }
+    }
+
+    private parseInstruction(prompt: string): AgentInstruction | null {
+        try {
+            const parsed = JSON.parse(prompt);
+            if (!parsed || typeof parsed !== 'object') {
+                return null;
+            }
+
+            const rawAction = this.extractString(parsed, ['action', 'type']);
+            if (!rawAction) {
+                return null;
+            }
+
+            const action = rawAction.toLowerCase();
+            if (!['create', 'list', 'update', 'delete'].includes(action)) {
+                return null;
+            }
+
+            const entity = this.extractString(parsed, ['entity', 'model']);
+            if (!entity) {
+                return null;
+            }
+
+            const payload = this.extractObject(parsed, ['data', 'payload', 'record']);
+            const criteria = this.extractObject(parsed, ['criteria', 'where', 'filter']);
+
+            return {
+                action: action as AgentAction,
+                entity,
+                payload,
+                criteria,
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    private usageMessage(): string {
+        return [
+            'Provide JSON instructions so the OpenAI agent can execute them with your permissions.',
+            'Example:',
+            '```json',
+            '{',
+            '  "action": "create",',
+            '  "entity": "Example",',
+            '  "data": { "title": "Hello from the agent" }',
+            '}',
+            '```',
+            'The agent uses DataAccessor, so any field-level restrictions from your account are respected.',
+        ].join('\n');
+    }
+
+    private resolveEntity(modelName: string): Entity | null {
+        const models = this.adminizer.config.models;
+        if (!models) {
+            return null;
+        }
+
+        const loweredName = modelName.toLowerCase();
+        const match = Object.entries(models).find(([key, config]) => {
+            if (key.toLowerCase() === loweredName) {
+                return true;
+            }
+            if (typeof config === 'object' && config && 'model' in config && typeof config.model === 'string') {
+                return config.model.toLowerCase() === loweredName;
+            }
+            return false;
+        });
+
+        if (!match) {
+            return null;
+        }
+
+        const [configName, configValue] = match as [string, ModelConfig | boolean];
+        const normalizedConfig = this.normalizeModelConfig(configName, configValue);
+        const model = this.adminizer.modelHandler.model.get(normalizedConfig.model);
+
+        if (!model) {
+            return null;
+        }
+
+        return {
+            name: configName,
+            uri: `${this.adminizer.config.routePrefix}/model/${configName}`,
+            type: 'model',
+            config: normalizedConfig,
+            model,
+        };
+    }
+
+    private normalizeModelConfig(name: string, config: ModelConfig | boolean): ModelConfig {
+        const baseConfig: ModelConfig = {
+            model: name,
+            icon: 'description',
+            title: name,
+            list: true,
+            add: true,
+            edit: true,
+            remove: true,
+            view: true,
+        } as ModelConfig;
+
+        if (typeof config === 'boolean') {
+            return config ? baseConfig : {...baseConfig, list: false, add: false, edit: false, remove: false, view: false};
+        }
+
+        return {...baseConfig, ...config};
+    }
+
+    private userHasPermission(entity: Entity, user: UserAP, action: ActionType): boolean {
+        const token = this.getPermissionToken(entity, action);
+        return this.adminizer.accessRightsHelper.hasPermission(token, user);
+    }
+
+    private getPermissionToken(entity: Entity, action: ActionType): string {
+        const verb = ACTION_TOKENS[action];
+        const modelName = entity.model?.modelname ?? entity.config?.model ?? entity.name;
+        return `${verb}-${modelName}-${entity.type}`.toLowerCase();
+    }
+
+    private extractPrimaryKey(record: Partial<Record<string, unknown>>, entity: Entity): unknown {
+        if (!record) {
+            return undefined;
+        }
+        const primaryKey = (entity.model as any)?.primaryKey ?? 'id';
+        return (record as Record<string, unknown>)[primaryKey];
+    }
+
+    private extractString(source: any, keys: string[]): string | undefined {
+        for (const key of keys) {
+            const value = source?.[key];
+            if (typeof value === 'string' && value.trim().length > 0) {
+                return value.trim();
+            }
+        }
+        return undefined;
+    }
+
+    private extractObject(source: any, keys: string[]): Record<string, unknown> | undefined {
+        for (const key of keys) {
+            const value = source?.[key];
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                return value as Record<string, unknown>;
+            }
+        }
+        return undefined;
+    }
+}

--- a/src/system/bindAiAssistant.ts
+++ b/src/system/bindAiAssistant.ts
@@ -2,9 +2,11 @@ import {Adminizer} from '../lib/Adminizer';
 import {AiAssistantHandler} from '../lib/ai-assistant/AiAssistantHandler';
 import {DummyAiModelService} from '../lib/ai-assistant/DummyAiModelService';
 import {AbstractAiModelService} from '../lib/ai-assistant/AbstractAiModelService';
+import {OpenAiModelService} from '../lib/ai-assistant/OpenAiModelService';
 
 const modelFactories: Record<string, (adminizer: Adminizer) => AbstractAiModelService> = {
     dummy: (adminizer) => new DummyAiModelService(adminizer),
+    openai: (adminizer) => new OpenAiModelService(adminizer),
 };
 
 export async function bindAiAssistant(adminizer: Adminizer): Promise<void> {

--- a/test/openAiModelService.spec.ts
+++ b/test/openAiModelService.spec.ts
@@ -1,0 +1,107 @@
+import {describe, expect, it, vi} from 'vitest';
+import {OpenAiModelService} from '../src/lib/ai-assistant/OpenAiModelService';
+import {UserAP} from '../src/models/UserAP';
+import {Adminizer} from '../src/lib/Adminizer';
+import {ActionType, ModelConfig} from '../src/interfaces/adminpanelConfig';
+import {Entity} from '../src/interfaces/types';
+import {DataAccessor} from '../src/lib/DataAccessor';
+
+describe('OpenAiModelService', () => {
+    const createAdminizerStub = () => {
+        const modelCreate = vi.fn(async (data: Record<string, unknown>) => ({id: 42, ...data}));
+        const stubModel = {
+            modelname: 'example',
+            primaryKey: 'id',
+            create: modelCreate,
+        };
+
+        const accessRightsHelper = {
+            registerToken: vi.fn(),
+            hasPermission: vi.fn().mockReturnValue(true),
+        };
+
+        const config = {
+            routePrefix: '/adminizer',
+            models: {
+                Example: {
+                    model: 'example',
+                    title: 'Example',
+                    add: true,
+                    edit: true,
+                    list: true,
+                    remove: true,
+                    view: true,
+                } satisfies ModelConfig,
+            },
+        } as Adminizer['config'];
+
+        const adminizer = {
+            config,
+            accessRightsHelper,
+            modelHandler: {
+                model: {
+                    get: vi.fn(() => stubModel),
+                },
+            },
+        } as unknown as Adminizer;
+
+        const user: UserAP = {
+            id: 1,
+            login: 'openai',
+            groups: [],
+            isAdministrator: false,
+        } as unknown as UserAP;
+
+        return {adminizer, accessRightsHelper, stubModel, modelCreate, user};
+    };
+
+    it('returns usage instructions when the prompt is not JSON', async () => {
+        const {adminizer, user} = createAdminizerStub();
+        const service = new OpenAiModelService(adminizer, vi.fn());
+
+        const reply = await service.generateReply('hello world', [], user);
+
+        expect(reply).toContain('Provide JSON instructions');
+    });
+
+    it('creates a record using DataAccessor when JSON command is provided', async () => {
+        const {adminizer, user, modelCreate} = createAdminizerStub();
+        const accessorStub = {} as DataAccessor;
+        const accessorFactory = vi.fn((entity: Entity, currentUser: UserAP, action: ActionType) => {
+            expect(entity.name).toBe('Example');
+            expect(currentUser).toBe(user);
+            expect(action).toBe('add');
+            return accessorStub;
+        });
+
+        const service = new OpenAiModelService(adminizer, accessorFactory);
+        const payload = {
+            action: 'create',
+            entity: 'Example',
+            data: {title: 'AI title'},
+        };
+
+        const reply = await service.generateReply(JSON.stringify(payload), [], user);
+
+        expect(accessorFactory).toHaveBeenCalledTimes(1);
+        expect(modelCreate).toHaveBeenCalledWith(payload.data, accessorStub);
+        expect(reply).toContain('Record created in Example');
+        expect(reply).toContain('AI title');
+    });
+
+    it('blocks creation when the user lacks permissions', async () => {
+        const {adminizer, user, accessRightsHelper} = createAdminizerStub();
+        accessRightsHelper.hasPermission.mockReturnValue(false);
+
+        const service = new OpenAiModelService(adminizer, vi.fn());
+        const payload = {
+            action: 'create',
+            entity: 'Example',
+            data: {title: 'Restricted'},
+        };
+
+        const reply = await service.generateReply(JSON.stringify(payload), [], user);
+
+        expect(reply).toContain('does not have permission');
+    });
+});


### PR DESCRIPTION
## Summary
- add an OpenAI AI assistant model service that executes JSON commands through DataAccessor
- seed an openai administrator account, register the model factory, and document the new fixture workflow
- cover the service with a dedicated unit test and extend fixture tokens for AI usage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6cff47a10832a8338202bd5afcd5b