### PR TITLE
Expose DataAccessor field metadata to power OpenAI agent writes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,6 @@
 ## 4.3.6
+- Added a `DataAccessor.listFieldMetadata` helper that surfaces accessible fields with descriptions for permission-aware flows.
+- Extended the fixture OpenAI data agent with field-discovery and record-creation tools driven by DataAccessor permissions.
 - Configured OpenAI API integration through environment variables for AI assistant functionality.
 - Added dotenv support for loading environment variables from .env file in fixture startup.
 - Created OpenAI setup documentation with security best practices and troubleshooting guide.


### PR DESCRIPTION
## Summary
- add a `listFieldMetadata` helper to DataAccessor so callers can discover accessible columns with descriptions
- extend the fixture OpenAI agent with tools for field inspection and record creation that reuse DataAccessor permissions
- refresh the AI assistant documentation and history log to cover the new tooling

## Testing
- npm run build *(fails: missing optional dependency `shelljs` in build script)*

------
https://chatgpt.com/codex/tasks/task_e_68d76eff415c832ab3fb77b3e845b296