### PR TITLE
feat: allow the OpenAI fixture agent to introspect writable fields

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 4.3.7
+- Added `DataAccessor.describeAccessibleFields()` to expose per-action field metadata for AI and form builders.
+- Extended the fixture OpenAI agent with schema introspection, payload sanitisation, and required-field validation when creating records.
+- Documented the new workflow and updated tests to cover the field discovery command.
+
 ## 4.3.6
 - Configured OpenAI API integration through environment variables for AI assistant functionality.
 - Added dotenv support for loading environment variables from .env file in fixture startup.

--- a/docs/AccessRights/AccessRightsModelFields.md
+++ b/docs/AccessRights/AccessRightsModelFields.md
@@ -116,3 +116,31 @@ In this example:
 * `internalStatus` is only shown to admins and QA team members.
 * `createdAt` is hidden entirely.
 * Only records where the current user is the `owner` are accessible to non-admins.
+
+---
+
+#### **Field Metadata Export (`describeAccessibleFields`)**
+
+When building automated tooling—such as the fixture's OpenAI agent—it is often necessary to know not only which fields are
+visible, but also how they should be populated. The new `describeAccessibleFields()` helper returns a curated list of descriptors
+for the current action, honouring all checks described above. Each descriptor contains:
+
+* `key`, `title`, and `type` — the normalized field metadata.
+* `required` / `disabled` flags — so clients know whether a value must be supplied.
+* `description`, `placeholder`, `allowedValues`, and `options` — sourced from the field configuration when present.
+* `association` details — identifies the linked model and whether the relation accepts multiple entries.
+
+The method is especially useful for AI or form builders because it eliminates guesswork and guarantees parity with the existing
+permission model:
+
+```ts
+const accessor = new DataAccessor(adminizer, user, entity, 'add');
+const fields = accessor.describeAccessibleFields();
+
+fields.forEach((field) => {
+    console.log(`${field.key} → ${field.type}`);
+});
+```
+
+Consumers can confidently pre-validate payloads, filter out forbidden attributes, and craft meaningful prompts before they reach
+the persistence layer.

--- a/docs/AiAssistant.md
+++ b/docs/AiAssistant.md
@@ -42,6 +42,25 @@ Example payload for creating a record:
 
 If the user lacks the required access token (for example, `create-example-model`), the agent responds with an authorization error instead of touching the database. The `openai` fixture user (`login: openai`, `password: openai`) belongs to the administrators group, granting full access for experimentation. Regular users can be granted permissions by assigning the `ai-assistant-openai` token to their groups.
 
+### Discovering available fields
+
+Before issuing a `create` command the agent can now describe the exact payload shape that is accepted for the chosen model. This
+is achieved through the `fields` action which asks `DataAccessor` for the list of writable fields, their types, requirements, and
+association hints. The agent trims any values that are not allowed and will stop execution if mandatory properties are missing.
+
+Example request for the schema:
+
+```json
+{
+  "action": "fields",
+  "entity": "Example"
+}
+```
+
+The response enumerates each accessible field, including required flags, optional descriptions (taken from field tooltips),
+allowed enums, and association targets. When a `create` command is executed afterwards the agent automatically reuses this
+metadata to validate the payload and report missing values instead of failing with a generic database error.
+
 ## Backend Overview
 
 * `AiAssistantHandler` keeps registered model services and in-memory conversation history per user and model.

--- a/test/dataAccesor.spec.ts
+++ b/test/dataAccesor.spec.ts
@@ -160,6 +160,20 @@ describe('DataAccessor test', () => {
     expect(result[0]).toHaveProperty('guardedField');
   });
 
+  it('describeAccessibleFields exposes only permitted fields with metadata', () => {
+    instance = new DataAccessor(adminizer, adminUser, entity, 'add');
+    const descriptors = instance.describeAccessibleFields();
+    const titleField = descriptors.find((descriptor) => descriptor.key === 'title');
+    expect(titleField).toBeTruthy();
+    expect(titleField?.type).toBeDefined();
+    expect(titleField?.title).toBe('Title');
+
+    instance = new DataAccessor(adminizer, managerUser, entity, 'add');
+    const restrictedDescriptors = instance.describeAccessibleFields();
+    const restrictedKeys = restrictedDescriptors.map((descriptor) => descriptor.key);
+    expect(restrictedKeys).not.toContain('guardedField');
+  });
+
   it('`sanitizeUserRelationAccess()` includes user ID in criteria', async () => {
     // if (entity.config && entity.config.userAccessRelation) {
     //   entity.config.userAccessRelation = {


### PR DESCRIPTION
## Summary
- add `DataAccessor.describeAccessibleFields()` to expose permission-aware field descriptors for automation use
- extend the fixture OpenAI model to validate create payloads and provide a `fields` schema lookup action
- document the workflow update and cover the new behavior with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d76eff415c832ab3fb77b3e845b296