### PR TITLE
feat: add DataAccessor field metadata and expand OpenAI agent tools

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 4.3.7
+- Added a `listAccessibleFields()` helper to `DataAccessor`, documented the metadata shape, and covered it with tests for permission-sensitive scenarios.
+- Expanded the fixture OpenAI data agent with field discovery and record-creation tools that rely on `DataAccessor` permissions so the assistant can create entries safely.
+
 ## 4.3.6
 - Configured OpenAI API integration through environment variables for AI assistant functionality.
 - Added dotenv support for loading environment variables from .env file in fixture startup.

--- a/docs/AccessRights/AccessRightsModelFields.md
+++ b/docs/AccessRights/AccessRightsModelFields.md
@@ -28,6 +28,25 @@ This class:
 * **Association support**: Handles both `BelongsTo` and `HasMany` style associations with optional population and recursive field filtering.
 * **Multi-level access logic**: Enforces both direct and intermediate relation-based access restrictions using the `userAccessRelation` model config key.
 * **CRUD-agnostic**: Designed to be used with various actions (`add`, `edit`, `view`, `list`) with unified processing logic.
+* **Field metadata helper**: `listAccessibleFields()` returns a normalized summary of writable fields so automated clients (for example, AI agents) can build valid payloads without guessing configuration details.
+
+#### **Listing Accessible Fields**
+
+Call `listAccessibleFields()` after constructing a `DataAccessor` to receive an array of metadata objects with the following shape:
+
+```ts
+{
+  name: string;
+  label: string;
+  type?: string;
+  required: boolean;
+  description?: string;
+  association?: { model?: string; collection?: string; multiple: boolean };
+  options?: BaseFieldConfig['options'];
+}
+```
+
+Only fields that pass the current user's permission checks are returned. This makes it safe to auto-generate forms or AI prompts because the helper mirrors the same field filtering applied during `add`/`edit` operations.
 
 ---
 

--- a/docs/AiAssistant.md
+++ b/docs/AiAssistant.md
@@ -40,7 +40,7 @@ Example payload for creating a record:
 }
 ```
 
-If the user lacks the required access token (for example, `create-example-model`), the agent responds with an authorization error instead of touching the database. The `openai` fixture user (`login: openai`, `password: openai`) belongs to the administrators group, granting full access for experimentation. Regular users can be granted permissions by assigning the `ai-assistant-openai` token to their groups.
+If the user lacks the required access token (for example, `create-example-model`), the agent responds with an authorization error instead of touching the database. The `openai` fixture user (`login: openai`, `password: openai`) belongs to the administrators group, granting full access for experimentation. Regular users can be granted permissions by assigning the `ai-assistant-openai` token to their groups. The fixture agent now exposes helper tooling so conversations can first discover which fields are writable (`describe_model_fields`) and then create data (`create_model_record`) without violating model permissions.
 
 ## Backend Overview
 
@@ -81,6 +81,9 @@ OpenAI's Agents API while still relying on Adminizer's abstractions:
   `AbstractAiModelService`.
 * Database reads are performed through `DataAccessor`, which means the usual access control and field
   sanitisation rules are enforced automatically.
+* `describe_model_fields` surfaces the list of writable fields using `DataAccessor.listAccessibleFields()` so prompts can include accurate payloads.
+* `query_model_records` retrieves live data with per-field filtering while respecting the caller's `read-*` permissions.
+* `create_model_record` persists new rows via `DataAccessor` and automatically applies user ownership rules before saving.
 * Conversation history is converted into the `@openai/agents` protocol so follow-up questions can
   build on previous answers.
 

--- a/test/dataAccesor.spec.ts
+++ b/test/dataAccesor.spec.ts
@@ -160,6 +160,25 @@ describe('DataAccessor test', () => {
     expect(result[0]).toHaveProperty('guardedField');
   });
 
+  it('`listAccessibleFields()` describes fields based on permissions', () => {
+    instance = new DataAccessor(adminizer, editorUser, entity, 'add');
+    const editorFields = instance.listAccessibleFields();
+    const guardedField = editorFields.find(field => field.name === 'guardedField');
+    const titleField = editorFields.find(field => field.name === 'title');
+
+    expect(editorFields.length).toBeGreaterThan(0);
+    expect(guardedField?.label).toBe('Restricted Field');
+    expect(titleField?.label).toBe('Title');
+    expect(titleField?.required).toBe(true);
+
+    instance = new DataAccessor(adminizer, managerUser, entity, 'add');
+    const managerFields = instance.listAccessibleFields();
+    expect(managerFields.find(field => field.name === 'guardedField')).toBeUndefined();
+
+    instance = new DataAccessor(adminizer, defaultUser, entity, 'add');
+    expect(instance.listAccessibleFields()).toEqual([]);
+  });
+
   it('`sanitizeUserRelationAccess()` includes user ID in criteria', async () => {
     // if (entity.config && entity.config.userAccessRelation) {
     //   entity.config.userAccessRelation = {


### PR DESCRIPTION
## Summary
- add a `listAccessibleFields` helper to `DataAccessor` and document the metadata it returns
- extend the fixture OpenAI data agent with tools for describing fields and creating records through `DataAccessor`
- add unit coverage and changelog notes for the new helper and agent capabilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d76eff415c832ab3fb77b3e845b296