### PR TITLE
Expose DataAccessor metadata and enhance OpenAI data agent

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 4.3.7
+- Exposed `DataAccessor#listAccessibleFields` so callers (including AI agents) can inspect writeable fields with metadata.
+- Enabled the fixture OpenAI data agent to describe model fields and create records through `DataAccessor` respecting user permissions.
+- Documented the new metadata API and AI assistant tooling updates.
+
 ## 4.3.6
 - Configured OpenAI API integration through environment variables for AI assistant functionality.
 - Added dotenv support for loading environment variables from .env file in fixture startup.

--- a/docs/AccessRights/AccessRightsModelFields.md
+++ b/docs/AccessRights/AccessRightsModelFields.md
@@ -28,6 +28,31 @@ This class:
 * **Association support**: Handles both `BelongsTo` and `HasMany` style associations with optional population and recursive field filtering.
 * **Multi-level access logic**: Enforces both direct and intermediate relation-based access restrictions using the `userAccessRelation` model config key.
 * **CRUD-agnostic**: Designed to be used with various actions (`add`, `edit`, `view`, `list`) with unified processing logic.
+* **Field metadata discovery**: `listAccessibleFields()` returns sanitized metadata describing every field the current user can touch for the current action.
+
+---
+
+#### **Field Metadata API**
+
+The `listAccessibleFields()` helper exposes a lightweight description of the fields that remain after
+all permission checks. Each entry includes:
+
+| Property | Description |
+| --- | --- |
+| `key` | Field identifier as used in payloads and criteria |
+| `label` | Human-friendly title derived from the model configuration |
+| `type` | Normalised field type (e.g. `string`, `association-many`, `jsoneditor`) |
+| `required` | Indicates whether the field must be supplied when creating or editing records |
+| `description` | Tooltip/description text from the configuration (when available) |
+| `readOnly` | True if the field is marked as disabled/readonly for the current user |
+| `isAssociation` | True for relation fields (`association` or `association-many`) |
+| `isCollection` | True only for `association-many` relations |
+| `options` | Widget-specific options (when defined) |
+| `choices` | The `isIn` enumeration, useful for select-style inputs |
+
+Because the method respects the accessor action (`add`, `edit`, `list`, or `view`), it can be used to
+drive dynamic form generation, AI assistant hints, or API schema discovery without leaking fields that
+the caller cannot access.
 
 ---
 

--- a/docs/AiAssistant.md
+++ b/docs/AiAssistant.md
@@ -79,7 +79,7 @@ OpenAI's Agents API while still relying on Adminizer's abstractions:
 
 * The agent implementation lives in `fixture/helpers/ai/OpenAiDataAgentService.ts` and extends
   `AbstractAiModelService`.
-* Database reads are performed through `DataAccessor`, which means the usual access control and field
+* Database reads and writes are performed through `DataAccessor`, which means the usual access control and field
   sanitisation rules are enforced automatically.
 * Conversation history is converted into the `@openai/agents` protocol so follow-up questions can
   build on previous answers.
@@ -95,3 +95,16 @@ export OPENAI_AGENT_MODEL="gpt-4.1-mini" # optional override
 available the fixture automatically registers the model, exposes it in the assistant model list, and
 prefers it as the default chat model. If the key is missing the agent stays disabled and a warning is
 logged during boot.
+
+### Tools exposed to the agent
+
+The `openai-data` agent wires three tools into the Agents runtime so prompts can stay declarative:
+
+1. `describe_model_fields` – lists the fields that are available for a given action (`add`, `edit`, `list`, or `view`).
+   The response mirrors `DataAccessor#listAccessibleFields`, so the assistant can reason about required inputs before
+   attempting a mutation.
+2. `query_model_records` – fetches records with the active user's `list` permissions, optionally filtered and projected.
+3. `create_model_record` – creates a new record using the `add` permissions of the active user.
+
+Every tool call is executed with the same permission checks the admin panel would apply, so the agent cannot escalate
+privileges beyond the assigned access tokens.

--- a/test/dataAccesor.spec.ts
+++ b/test/dataAccesor.spec.ts
@@ -122,6 +122,20 @@ describe('DataAccessor test', () => {
     expect(instance.getFieldsConfig()).toBeUndefined();
   });
 
+  it('listAccessibleFields reports metadata for allowed fields only', () => {
+    instance = new DataAccessor(adminizer, editorUser, entity, 'add');
+    const metadata = instance.listAccessibleFields();
+    const titleField = metadata.find(field => field.key === 'title');
+    const guardedField = metadata.find(field => field.key === 'guardedField');
+
+    expect(titleField?.label).toBe('Title');
+    expect(titleField?.required).toBe(true);
+    expect(guardedField).toBeDefined();
+
+    instance = new DataAccessor(adminizer, defaultUser, entity, 'add');
+    expect(instance.listAccessibleFields()).toEqual([]);
+  });
+
   it('Populated selfAssociation has guardedField for admin', () => {
     instance = new DataAccessor(adminizer, adminUser, entity, 'edit');
     expect(instance.getFieldsConfig().selfAssociation.populated).toHaveProperty('guardedField');


### PR DESCRIPTION
## Summary
- add a `listAccessibleFields` helper to `DataAccessor` with supporting documentation and tests
- extend the fixture OpenAI data agent with tools to describe fields and create records through `DataAccessor`
- document the new assistant tooling and note the changes in `HISTORY.md`

## Testing
- npm test
- npm run build
- npm run start


------
https://chatgpt.com/codex/tasks/task_e_68d76eff415c832ab3fb77b3e845b296