### PR TITLE
Enable fixture AI agent writes via DataAccessor

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 4.3.8
+- Added write-capable `create_model_record` tool to the fixture OpenAI agent with DataAccessor permission checks.
+- Updated agent instructions to use JSON envelopes and documented the new command format.
+- Switched the fixture configuration to the single `openai-data` model so reads and writes share one assistant.
+
 ## 4.3.7
 - Added `DataAccessor.describeAccessibleFields()` to expose per-action field metadata for AI and form builders.
 - Extended the fixture OpenAI agent with schema introspection, payload sanitisation, and required-field validation when creating records.

--- a/fixture/adminizerConfig.ts
+++ b/fixture/adminizerConfig.ts
@@ -437,8 +437,8 @@ const config: AdminpanelConfig = {
     },
     aiAssistant: {
         enabled: true,
-        defaultModel: 'openai',
-        models: ['openai'],
+        defaultModel: 'openai-data',
+        models: ['openai-data'],
     },
     routePrefix: routePrefix,
     // routePrefix: "/admin",


### PR DESCRIPTION
## Summary
- extend the fixture OpenAI data agent with a create_model_record tool that writes through DataAccessor
- update the fixture configuration and documentation to reference the single openai-data assistant model
- record the new workflow in HISTORY.md and describe the JSON command envelopes for reads and writes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d776dec6e0832a8d33224c09bde433