### PR TITLE
Enable OpenAI agent record creation via JSON commands

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 4.3.8
+- Added a `create_model_record` OpenAI tool that persists records through `DataAccessor` with the caller's write permissions.
+- Relaxed the query tool schema to allow optional filters and documented the JSON command workflow.
+- Updated the fixture configuration to expose only the `openai-data` assistant model by default.
+
 ## 4.3.7
 - Added `DataAccessor.describeAccessibleFields()` to expose per-action field metadata for AI and form builders.
 - Extended the fixture OpenAI agent with schema introspection, payload sanitisation, and required-field validation when creating records.

--- a/fixture/adminizerConfig.ts
+++ b/fixture/adminizerConfig.ts
@@ -437,8 +437,8 @@ const config: AdminpanelConfig = {
     },
     aiAssistant: {
         enabled: true,
-        defaultModel: 'openai',
-        models: ['openai'],
+        defaultModel: 'openai-data',
+        models: ['openai-data'],
     },
     routePrefix: routePrefix,
     // routePrefix: "/admin",


### PR DESCRIPTION
## Summary
- allow the OpenAI fixture agent to execute direct JSON commands and register a create_model_record tool backed by DataAccessor
- keep only the openai-data model active in the fixture AI assistant configuration
- document the JSON command workflow and log the changes in HISTORY

## Testing
- npm install *(fails: peer dependency conflict between @openai/agents@0.1.6 and zod@4.1.11)*
- npm run build *(fails: missing shelljs due to failed dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68d776dec6e0832a8d33224c09bde433